### PR TITLE
feat: put BLE client behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,16 @@ tokio = { version =  "1.43.0", features=["sync", "rt"] }
 tokio-stream = { version = "0.1.17" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-bluer = { version = "0.17.3", features=["bluetoothd"] }
+bluer = { version = "0.17.3", features = ["bluetoothd"], optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-bluest = { version = "0.6.7" }
+bluest = { version = "0.6.7", optional = true }
 
 [dev-dependencies]
 hex = "0.4"
 tokio = { version =  "1.40.0", features=["full"] }
 
 [features]
+default = ["ble_client"]
 serde = ["dep:serde"]
+ble_client = ["dep:bluer", "dep:bluest"]

--- a/src/ble_client/linux.rs
+++ b/src/ble_client/linux.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "linux")]
-
 //! Linux specific implementation
 
 use crate::parse_manufacturer_data;

--- a/src/ble_client/macos.rs
+++ b/src/ble_client/macos.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "macos")]
-
 //! MacOS specific implementation
 
 use crate::{err::*, DeviceState};

--- a/src/ble_client/mod.rs
+++ b/src/ble_client/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(all(target_os = "linux", feature = "ble_client"))]
+#[path = "linux.rs"]
+mod ble_client;
+#[cfg(all(target_os = "macos", feature = "ble_client"))]
+#[path = "macos.rs"]
+mod ble_client;
+
+#[cfg(feature = "ble_client")]
+pub(crate) use ble_client::*;

--- a/src/err.rs
+++ b/src/err.rs
@@ -28,14 +28,14 @@ pub enum Error {
     ClientClosedChannel,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "ble_client"))]
 impl From<bluest::Error> for Error {
     fn from(e: bluest::Error) -> Self {
         Error::Bluest(e.to_string())
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "ble_client"))]
 impl From<bluer::Error> for Error {
     fn from(e: bluer::Error) -> Self {
         Error::Bluer(e.to_string())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,9 @@
 //! - <https://github.com/PeterGrace/vedirect_rs>
 
 mod bit_reader;
+#[cfg(feature = "ble_client")]
+mod ble_client;
 mod err;
-mod linux;
-mod macos;
 mod model;
 mod record;
 
@@ -70,11 +70,6 @@ pub use crate::err::*;
 pub use model::*;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio_stream::{wrappers::UnboundedReceiverStream, Stream};
-
-#[cfg(target_os = "linux")]
-use linux::open_stream as _open_stream;
-#[cfg(target_os = "macos")]
-use macos::open_stream as _open_stream;
 
 use record::Record;
 
@@ -114,6 +109,7 @@ pub fn parse_manufacturer_data(
 ///     }
 /// # }
 /// ```
+#[cfg(feature = "ble_client")]
 pub fn open_stream(
     device_name: String,
     device_encryption_key: Vec<u8>,
@@ -121,7 +117,7 @@ pub fn open_stream(
     let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
 
     tokio::spawn(async move {
-        let _ = _open_stream(device_name, device_encryption_key, sender.clone()).await;
+        let _ = ble_client::open_stream(device_name, device_encryption_key, sender.clone()).await;
     });
 
     Ok(UnboundedReceiverStream::new(receiver))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ mod record;
 pub use crate::err::*;
 pub use model::*;
 use tokio::sync::mpsc::UnboundedSender;
+#[cfg(feature = "ble_client")]
 use tokio_stream::{wrappers::UnboundedReceiverStream, Stream};
 
 use record::Record;


### PR DESCRIPTION
**Description:**
Introduce the feature flag "ble_client" so that this crate can be used for either a full implementation or just for the models/`bit_reader` implementations. The feature flag is by default on, so this shouldn't change anything for existing uses.

**Implementation:**

- add `ble_client` feature flag
- move `linux.rs` and `macos.rs` to `ble_client/` folder
- put `open_stream` and `ble_client/` behind the feature flag